### PR TITLE
fix classOrObjectMethod and cleanup

### DIFF
--- a/remap.js
+++ b/remap.js
@@ -11,18 +11,16 @@
 
 'use strict';
 
-const t = require('babel-types')
-
-module.exports = function remapHelper (path, callId) {
+module.exports = function remapHelper (path) {
   let node = path.node;
   if (node.generator) return;
 
   path.traverse(awaitVisitor);
 
   if (path.isClassMethod() || path.isObjectMethod()) {
-    return classOrObjectMethod(path, callId);
+    return classOrObjectMethod(path);
   } else {
-    return plainFunction(path, callId);
+    return plainFunction(path)
   }
 };
 
@@ -39,17 +37,11 @@ var awaitVisitor = {
   }
 };
 
-function classOrObjectMethod(path, callId) {
-  let node = path.node,
-    body = node.body,
-    container;
+function classOrObjectMethod(path) {
+  let node = path.node;
 
   node.async = false;
-
-  container = t.functionExpression(null, [], t.blockStatement(body.body), true);
-  container.shadow = true;
-
-  body.body = [t.returnStatement(t.callExpression(t.callExpression(callId, [container]), []))];
+  node.generator = true;
 }
 
 function plainFunction (path) {


### PR DESCRIPTION
So my last PR made it transpile class and object methods fine, but they transpiled to the other way, which we're looking for just plain converting from async to generator. 

This PR fixes that issue, and also removes the `callId` so that it doesn't put the extra stuff at the top for the other method.

Converts:

```
async function foo () {
  await helloWorld()
}

const bar = async function () {
  await helloWorld()
}

const test = async () => await helloWorld()

class TestClass {
  static async method () {
    await helloWorld()
  }
}

const baz = {
  async test () {
    await helloWorld()
  }
}
```

to:

```
function* foo() {
  yield helloWorld();
}

const bar = function* () {
  yield helloWorld();
};

const test = function* () {
  return yield helloWorld();
};

class TestClass {
  static *method() {
    yield helloWorld();
  }
}

const baz = {
  *test() {
    yield helloWorld();
  }
};
```
